### PR TITLE
Fixed update + rebuild for v0.9.x versions.

### DIFF
--- a/bin/nim-vm
+++ b/bin/nim-vm
@@ -195,7 +195,10 @@ function koch_build() {
 
     case "$1" in
         (v0.9.*)
-            mv bin/nimrod bin/nim
+            if [ ! -f bin/nim ]; then
+                # make it available as nim
+                ln -s nimrod bin/nim
+            fi
             ;;
     esac
 }


### PR DESCRIPTION
The way I used to get 'nim' available for the 0.9 'nimrod' builds was failing to update/rebuild because that wants to use nimrod. I know just add a symlink for that purpose.
