### PR TITLE
Set executable bit for all

### DIFF
--- a/bin/nim-vm
+++ b/bin/nim-vm
@@ -323,6 +323,7 @@ function rebuild_version() {
 
     bindir=$(get_bindir)
     if [ "$NIMVM_VERSION_LINK" = "1" ]; then
+        chmod a+x $bindir/nim.$version
         ln -nfs $version_dir/bin/nim $bindir/nim.$version
     fi
 }


### PR DESCRIPTION
I have processes like Apache running Nim and that fails if not
"everybody" can run it. This fix should not matter for most people.
